### PR TITLE
ニコニコ漫画対応

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,6 +17,7 @@
 	"host_permissions": [
 		"*://lohas.nicoseiga.jp/",
 		"*://seiga.nicovideo.jp/",
+        "*://manga.nicovideo.jp/",
 		"https://dcdn.cdn.nimg.jp/",
 		"https://deliver.cdn.nicomanga.jp/"
 	],
@@ -26,18 +27,18 @@
 	"content_scripts": [
 		{
 			"css": [ "content_scripts/main.css" ],
-			"matches": [ "*://seiga.nicovideo.jp/*" ],
+			"matches": [ "*://seiga.nicovideo.jp/*", "*://manga.nicovideo.jp/*"  ],
 			"run_at": "document_start"
 		}, {
 			"js":  [ "content_scripts/main.js" ],
-			"matches": [ "*://seiga.nicovideo.jp/*" ]
+			"matches": [ "*://seiga.nicovideo.jp/*", "*://manga.nicovideo.jp/*" ]
 		}, {
 			"js":  [ "content_scripts/seiga.js" ],
 			"matches": [ "*://seiga.nicovideo.jp/seiga/im*" ],
 			"run_at": "document_start"
 		}, {
 			"js":  [ "content_scripts/watch.js" ],
-			"matches": [ "*://seiga.nicovideo.jp/watch/mg*" ],
+			"matches": [ "*://manga.nicovideo.jp/watch/mg*" ],
 			"run_at": "document_start"
 		}
 	],
@@ -45,7 +46,7 @@
 	"web_accessible_resources": [
 		{
 			"resources": [ "inject.js" ],
-			"matches": [ "*://seiga.nicovideo.jp/*" ]
+			"matches": [ "*://seiga.nicovideo.jp/*", "*://seiga.nicovideo.jp/*" ]
 		}
 	]
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -46,7 +46,7 @@
 	"web_accessible_resources": [
 		{
 			"resources": [ "inject.js" ],
-			"matches": [ "*://seiga.nicovideo.jp/*", "*://seiga.nicovideo.jp/*" ]
+			"matches": [ "*://seiga.nicovideo.jp/*", "*://manga.nicovideo.jp/*" ]
 		}
 	]
 }


### PR DESCRIPTION
2024年6月頃に、ニコニコに起こったサイバー攻撃によって一時的にニコニコが利用できない状態が続いていました。

同年8月頃にニコニコ動画は復活しました。しかしながらニコニコ漫画を観覧する際のURLが以下のように変わりました。このプルリクエストはその変更に対応するためのプルリクエストです。

seiga.nicovideo.jp/watch/mg******* -> manga.nicovideo.jp/watch/mg*******

よろしくお願いいたします。 